### PR TITLE
feat: add input validation for domains and IP addresses

### DIFF
--- a/internal/provider/resource_cname_record.go
+++ b/internal/provider/resource_cname_record.go
@@ -24,16 +24,18 @@ func resourceCNAMERecord() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"domain": {
-				Description: "Domain to create a CNAME record for",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Description:      "Domain to create a CNAME record for",
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validateDomain(),
 			},
 			"target": {
-				Description: "Value of the CNAME record where traffic will be directed to from the configured domain value",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Description:      "Value of the CNAME record where traffic will be directed to from the configured domain value",
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validateDomain(),
 			},
 		},
 	}

--- a/internal/provider/resource_dns_record.go
+++ b/internal/provider/resource_dns_record.go
@@ -21,16 +21,18 @@ func resourceDNSRecord() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"domain": {
-				Description: "DNS record domain",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Description:      "DNS record domain",
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validateDomain(),
 			},
 			"ip": {
-				Description: "IP address to route traffic to from the DNS record domain",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Description:      "IP address to route traffic to from the DNS record domain",
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validateIPAddress(),
 			},
 		},
 	}

--- a/internal/provider/validation.go
+++ b/internal/provider/validation.go
@@ -1,0 +1,34 @@
+package provider
+
+import (
+	"net"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// domainRegex matches valid domain names.
+// Allows alphanumeric characters, hyphens, underscores, and dots.
+// Each label must start and end with alphanumeric characters.
+var domainRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$`)
+
+// validateDomain returns a schema validation function for domain names.
+func validateDomain() schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(validation.All(
+		validation.StringLenBetween(1, 253),
+		validation.StringMatch(domainRegex, "must be a valid domain name"),
+	))
+}
+
+// validateIPAddress returns a schema validation function for IP addresses.
+// Accepts both IPv4 and IPv6 addresses.
+func validateIPAddress() schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(func(v interface{}, k string) (warnings []string, errors []error) {
+		value := v.(string)
+		if ip := net.ParseIP(value); ip == nil {
+			errors = append(errors, validation.InvalidIPAddress(k, value).([]error)...)
+		}
+		return warnings, errors
+	})
+}


### PR DESCRIPTION
## Summary

Adds schema validation to catch invalid input at plan time rather than failing at the Pi-hole API.

### Changes
- New `validation.go` with reusable validators
- Domain validation: regex matching valid domain names (alphanumeric, hyphens, underscores, dots), 1-253 chars
- IP validation: uses `net.ParseIP` to validate both IPv4 and IPv6 addresses

### Applied to
- `pihole_dns_record`: `domain` and `ip` fields
- `pihole_cname_record`: `domain` and `target` fields

## Test plan
- Invalid domain like `!!invalid!!` should fail validation at plan time
- Invalid IP like `not-an-ip` should fail validation at plan time
- Valid domains and IPs should pass through to the API

Closes #3