### PR TITLE
docs: explain CNAME delete mutex purpose

### DIFF
--- a/internal/provider/resource_cname_record.go
+++ b/internal/provider/resource_cname_record.go
@@ -10,6 +10,11 @@ import (
 	pihole "github.com/ryanwholey/go-pihole"
 )
 
+// resourceDeleteMutex serializes CNAME delete operations to work around a race
+// condition in the Pi-hole API. When multiple CNAME records are deleted
+// concurrently (e.g., during terraform destroy), some deletions silently fail,
+// leaving orphaned records. This mutex ensures deletes happen sequentially.
+// See: https://github.com/ryanwholey/terraform-provider-pihole/issues/68
 var resourceDeleteMutex sync.Mutex
 
 // resourceCNAMERecord returns the CNAME Terraform resource management configuration


### PR DESCRIPTION
## Summary

Adds documentation explaining why the `resourceDeleteMutex` exists in the CNAME resource.

### Context

The mutex was added in [ryanwholey/terraform-provider-pihole#79](https://github.com/ryanwholey/terraform-provider-pihole/pull/79) to fix [issue #68](https://github.com/ryanwholey/terraform-provider-pihole/issues/68), but no comment explained the reasoning.

### Root Cause

The Pi-hole API has a race condition where concurrent CNAME delete operations can silently fail, leaving orphaned records in Pi-hole that Terraform thinks were deleted.

### The Fix

The mutex serializes all CNAME delete operations so they execute one at a time, avoiding the race condition.

## Test plan

Documentation only - no functional changes.

Closes #7