### PR TITLE
refactor: internalize Pi-hole v6 API client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.22
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
-	github.com/ryanwholey/go-pihole v1.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -128,16 +128,13 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/ryanwholey/go-pihole v1.2.0 h1:usJy/ON2UsjmdGr2sTGWV6x/p4PNju/QDhxfpaseeiA=
-github.com/ryanwholey/go-pihole v1.2.0/go.mod h1:Qr4+O4BG8tJPVntmFHrFUUX9tluSWBLUBtKt6NrvAGw=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L3A=
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -1,0 +1,32 @@
+package pihole
+
+import "context"
+
+// Client is the interface for Pi-hole API operations.
+// Implementations exist for different Pi-hole versions (v5, v6).
+type Client interface {
+	// LocalDNS returns the service for managing local DNS A records
+	LocalDNS() LocalDNSService
+
+	// LocalCNAME returns the service for managing CNAME records
+	LocalCNAME() LocalCNAMEService
+
+	// SessionID returns the current session ID (for reuse across provider instances)
+	SessionID() string
+}
+
+// LocalDNSService manages local DNS A records (domain -> IP mappings)
+type LocalDNSService interface {
+	Create(ctx context.Context, domain, ip string) (*DNSRecord, error)
+	Get(ctx context.Context, domain string) (*DNSRecord, error)
+	List(ctx context.Context) ([]DNSRecord, error)
+	Delete(ctx context.Context, domain string) error
+}
+
+// LocalCNAMEService manages CNAME records (domain -> target domain mappings)
+type LocalCNAMEService interface {
+	Create(ctx context.Context, domain, target string) (*CNAMERecord, error)
+	Get(ctx context.Context, domain string) (*CNAMERecord, error)
+	List(ctx context.Context) ([]CNAMERecord, error)
+	Delete(ctx context.Context, domain string) error
+}

--- a/internal/pihole/errors.go
+++ b/internal/pihole/errors.go
@@ -1,0 +1,17 @@
+package pihole
+
+import "errors"
+
+var (
+	// ErrDNSNotFound is returned when a DNS record is not found
+	ErrDNSNotFound = errors.New("local DNS record not found")
+
+	// ErrCNAMENotFound is returned when a CNAME record is not found
+	ErrCNAMENotFound = errors.New("local CNAME record not found")
+
+	// ErrAuthFailed is returned when authentication fails
+	ErrAuthFailed = errors.New("authentication failed")
+
+	// ErrSessionNotFound is returned when session ID is not in auth response
+	ErrSessionNotFound = errors.New("session ID not found in response")
+)

--- a/internal/pihole/types.go
+++ b/internal/pihole/types.go
@@ -1,0 +1,31 @@
+package pihole
+
+// DNSRecord represents a local DNS A record
+type DNSRecord struct {
+	Domain string
+	IP     string
+}
+
+// CNAMERecord represents a CNAME record
+type CNAMERecord struct {
+	Domain string
+	Target string
+}
+
+// Config contains the configuration for creating a Pi-hole client
+type Config struct {
+	// BaseURL is the Pi-hole server URL (e.g., "http://pi.hole")
+	BaseURL string
+
+	// Password is the admin password for authentication
+	Password string
+
+	// UserAgent is sent with HTTP requests
+	UserAgent string
+
+	// CAFile is an optional path to a CA certificate for TLS
+	CAFile string
+
+	// SessionID can be provided to reuse an existing session
+	SessionID string
+}

--- a/internal/pihole/v6/client.go
+++ b/internal/pihole/v6/client.go
@@ -1,0 +1,191 @@
+package v6
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
+)
+
+const (
+	sessionHeader = "X-FTL-SID"
+)
+
+// Client implements pihole.Client for Pi-hole v6 API
+type Client struct {
+	baseURL   string
+	password  string
+	userAgent string
+	http      *http.Client
+
+	sessionID   string
+	sessionLock sync.RWMutex
+
+	dns   *dnsService
+	cname *cnameService
+}
+
+// NewClient creates a new Pi-hole v6 API client
+func NewClient(ctx context.Context, cfg pihole.Config) (*Client, error) {
+	httpClient := retryablehttp.NewClient()
+	httpClient.Logger = nil // Disable debug logging
+	stdClient := httpClient.StandardClient()
+
+	// Configure TLS if CA file provided
+	if cfg.CAFile != "" {
+		ca, err := os.ReadFile(cfg.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA file %q: %w", cfg.CAFile, err)
+		}
+
+		rootCAs := x509.NewCertPool()
+		if !rootCAs.AppendCertsFromPEM(ca) {
+			return nil, fmt.Errorf("failed to parse CA certificates from %q", cfg.CAFile)
+		}
+
+		stdClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: rootCAs,
+			},
+		}
+	}
+
+	c := &Client{
+		baseURL:   cfg.BaseURL,
+		password:  cfg.Password,
+		userAgent: cfg.UserAgent,
+		http:      stdClient,
+		sessionID: cfg.SessionID,
+	}
+
+	c.dns = &dnsService{client: c}
+	c.cname = &cnameService{client: c}
+
+	// If no session ID provided, authenticate now
+	if c.sessionID == "" {
+		if err := c.authenticate(ctx); err != nil {
+			return nil, fmt.Errorf("failed to authenticate: %w", err)
+		}
+	}
+
+	return c, nil
+}
+
+// LocalDNS returns the DNS record service
+func (c *Client) LocalDNS() pihole.LocalDNSService {
+	return c.dns
+}
+
+// LocalCNAME returns the CNAME record service
+func (c *Client) LocalCNAME() pihole.LocalCNAMEService {
+	return c.cname
+}
+
+// SessionID returns the current session ID
+func (c *Client) SessionID() string {
+	c.sessionLock.RLock()
+	defer c.sessionLock.RUnlock()
+	return c.sessionID
+}
+
+// authenticate obtains a session ID from the Pi-hole API
+func (c *Client) authenticate(ctx context.Context) error {
+	body := map[string]string{"password": c.password}
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/auth", bytes.NewReader(jsonBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return pihole.ErrAuthFailed
+	}
+
+	var result struct {
+		Session struct {
+			SID string `json:"sid"`
+		} `json:"session"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+
+	if result.Session.SID == "" {
+		return pihole.ErrSessionNotFound
+	}
+
+	c.sessionLock.Lock()
+	c.sessionID = result.Session.SID
+	c.sessionLock.Unlock()
+
+	return nil
+}
+
+// request performs an authenticated HTTP request
+func (c *Client) request(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(jsonBody)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+
+	c.sessionLock.RLock()
+	req.Header.Set(sessionHeader, c.sessionID)
+	c.sessionLock.RUnlock()
+
+	return c.http.Do(req)
+}
+
+// get performs an authenticated GET request
+func (c *Client) get(ctx context.Context, path string) (*http.Response, error) {
+	return c.request(ctx, http.MethodGet, path, nil)
+}
+
+// put performs an authenticated PUT request
+func (c *Client) put(ctx context.Context, path string, body interface{}) (*http.Response, error) {
+	return c.request(ctx, http.MethodPut, path, body)
+}
+
+// delete performs an authenticated DELETE request
+func (c *Client) delete(ctx context.Context, path string) (*http.Response, error) {
+	return c.request(ctx, http.MethodDelete, path, nil)
+}

--- a/internal/pihole/v6/cname.go
+++ b/internal/pihole/v6/cname.go
@@ -1,0 +1,118 @@
+package v6
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
+)
+
+const cnamePath = "/api/config/dns/cnameRecords"
+
+type cnameService struct {
+	client *Client
+}
+
+// cnameListResponse is the API response for listing CNAME records
+type cnameListResponse struct {
+	Config struct {
+		DNS struct {
+			CNAMERecords []string `json:"cnameRecords"`
+		} `json:"dns"`
+	} `json:"config"`
+}
+
+// List returns all CNAME records
+func (s *cnameService) List(ctx context.Context) ([]pihole.CNAMERecord, error) {
+	resp, err := s.client.get(ctx, cnamePath)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var result cnameListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return parseCNAMEs(result.Config.DNS.CNAMERecords), nil
+}
+
+// Get returns a specific CNAME record by domain
+func (s *cnameService) Get(ctx context.Context, domain string) (*pihole.CNAMERecord, error) {
+	records, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range records {
+		if r.Domain == domain {
+			return &r, nil
+		}
+	}
+
+	return nil, pihole.ErrCNAMENotFound
+}
+
+// Create adds a new CNAME record
+func (s *cnameService) Create(ctx context.Context, domain, target string) (*pihole.CNAMERecord, error) {
+	path := fmt.Sprintf("%s/%s", cnamePath, url.PathEscape(domain+","+target))
+
+	resp, err := s.client.put(ctx, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected status code: %d (expected 201)", resp.StatusCode)
+	}
+
+	return &pihole.CNAMERecord{Domain: domain, Target: target}, nil
+}
+
+// Delete removes a CNAME record
+func (s *cnameService) Delete(ctx context.Context, domain string) error {
+	// First get the record to find its target
+	record, err := s.Get(ctx, domain)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("%s/%s", cnamePath, url.PathEscape(domain+","+record.Target))
+
+	resp, err := s.client.delete(ctx, path)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected status code: %d (expected 204)", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// parseCNAMEs converts "domain,target" strings to CNAMERecord structs
+func parseCNAMEs(cnames []string) []pihole.CNAMERecord {
+	records := make([]pihole.CNAMERecord, 0, len(cnames))
+	for _, c := range cnames {
+		parts := strings.SplitN(c, ",", 2)
+		if len(parts) == 2 {
+			records = append(records, pihole.CNAMERecord{
+				Domain: parts[0],
+				Target: parts[1],
+			})
+		}
+	}
+	return records
+}

--- a/internal/pihole/v6/dns.go
+++ b/internal/pihole/v6/dns.go
@@ -1,0 +1,118 @@
+package v6
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
+)
+
+const dnsHostsPath = "/api/config/dns/hosts"
+
+type dnsService struct {
+	client *Client
+}
+
+// dnsListResponse is the API response for listing DNS records
+type dnsListResponse struct {
+	Config struct {
+		DNS struct {
+			Hosts []string `json:"hosts"`
+		} `json:"dns"`
+	} `json:"config"`
+}
+
+// List returns all local DNS records
+func (s *dnsService) List(ctx context.Context) ([]pihole.DNSRecord, error) {
+	resp, err := s.client.get(ctx, dnsHostsPath)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var result dnsListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return parseDNSHosts(result.Config.DNS.Hosts), nil
+}
+
+// Get returns a specific DNS record by domain
+func (s *dnsService) Get(ctx context.Context, domain string) (*pihole.DNSRecord, error) {
+	records, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range records {
+		if r.Domain == domain {
+			return &r, nil
+		}
+	}
+
+	return nil, pihole.ErrDNSNotFound
+}
+
+// Create adds a new DNS record
+func (s *dnsService) Create(ctx context.Context, domain, ip string) (*pihole.DNSRecord, error) {
+	path := fmt.Sprintf("%s/%s", dnsHostsPath, url.PathEscape(ip+" "+domain))
+
+	resp, err := s.client.put(ctx, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected status code: %d (expected 201)", resp.StatusCode)
+	}
+
+	return &pihole.DNSRecord{Domain: domain, IP: ip}, nil
+}
+
+// Delete removes a DNS record
+func (s *dnsService) Delete(ctx context.Context, domain string) error {
+	// First get the record to find its IP
+	record, err := s.Get(ctx, domain)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("%s/%s", dnsHostsPath, url.PathEscape(record.IP+" "+domain))
+
+	resp, err := s.client.delete(ctx, path)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected status code: %d (expected 204)", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// parseDNSHosts converts "IP domain" strings to DNSRecord structs
+func parseDNSHosts(hosts []string) []pihole.DNSRecord {
+	records := make([]pihole.DNSRecord, 0, len(hosts))
+	for _, h := range hosts {
+		parts := strings.SplitN(h, " ", 2)
+		if len(parts) == 2 {
+			records = append(records, pihole.DNSRecord{
+				IP:     parts[0],
+				Domain: parts[1],
+			})
+		}
+	}
+	return records
+}

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -2,13 +2,13 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	pihole "github.com/ryanwholey/go-pihole"
+	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
 )
 
 // getClient extracts the Pi-hole client from the provider meta interface.
 // Returns an error diagnostic if the client cannot be loaded.
-func getClient(meta interface{}) (*pihole.Client, diag.Diagnostics) {
-	client, ok := meta.(*pihole.Client)
+func getClient(meta interface{}) (pihole.Client, diag.Diagnostics) {
+	client, ok := meta.(pihole.Client)
 	if !ok {
 		return nil, diag.Errorf("could not load Pi-hole client")
 	}

--- a/internal/provider/data_source_cname_records.go
+++ b/internal/provider/data_source_cname_records.go
@@ -44,7 +44,7 @@ func dataSourceCNAMERecordsRead(ctx context.Context, d *schema.ResourceData, met
 		return diags
 	}
 
-	cnameList, err := client.LocalCNAME.List(ctx)
+	cnameList, err := client.LocalCNAME().List(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/data_source_dns_records.go
+++ b/internal/provider/data_source_dns_records.go
@@ -44,7 +44,7 @@ func dataSourceDNSRecordsRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diags
 	}
 
-	dnsList, err := client.LocalDNS.List(ctx)
+	dnsList, err := client.LocalDNS().List(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -30,11 +30,12 @@ func testAccPreCheck(t *testing.T) {
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		session, err := client.SessionAPI.Post(context.Background())
-		if err != nil {
-			t.Fatal(err.Error())
+		// Get session ID from the authenticated client
+		sessionID := client.SessionID()
+		if sessionID == "" {
+			t.Fatal("failed to get session ID from client")
 		}
-		if err := os.Setenv("__PIHOLE_SESSION_ID", session.SID); err != nil {
+		if err := os.Setenv("__PIHOLE_SESSION_ID", sessionID); err != nil {
 			t.Fatal(err.Error())
 		}
 	}

--- a/internal/provider/resource_cname_record.go
+++ b/internal/provider/resource_cname_record.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	pihole "github.com/ryanwholey/go-pihole"
+	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
 )
 
 // resourceDeleteMutex serializes CNAME delete operations to work around a race
@@ -56,7 +56,7 @@ func resourceCNAMERecordCreate(ctx context.Context, d *schema.ResourceData, meta
 	domain := d.Get("domain").(string)
 	target := d.Get("target").(string)
 
-	_, err := client.LocalCNAME.Create(ctx, domain, target)
+	_, err := client.LocalCNAME().Create(ctx, domain, target)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -73,9 +73,9 @@ func resourceCNAMERecordRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diags
 	}
 
-	record, err := client.LocalCNAME.Get(ctx, d.Id())
+	record, err := client.LocalCNAME().Get(ctx, d.Id())
 	if err != nil {
-		if errors.Is(err, pihole.ErrorLocalCNAMENotFound) {
+		if errors.Is(err, pihole.ErrCNAMENotFound) {
 			d.SetId("")
 			return nil
 		}
@@ -104,7 +104,7 @@ func resourceCNAMERecordDelete(ctx context.Context, d *schema.ResourceData, meta
 	resourceDeleteMutex.Lock()
 	defer resourceDeleteMutex.Unlock()
 
-	if err := client.LocalCNAME.Delete(ctx, d.Id()); err != nil {
+	if err := client.LocalCNAME().Delete(ctx, d.Id()); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_cname_record_test.go
+++ b/internal/provider/resource_cname_record_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	pihole "github.com/ryanwholey/go-pihole"
+	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
 )
 
 // TestAccCNAMERecord acceptance test for the CNAME record resource
@@ -54,7 +54,7 @@ func testLocalCNAMEResourceConfig(name string, domain string, target string) str
 		resource "pihole_cname_record" %q {
 			domain = %q
 			target = %q
-		}	
+		}
 	`, name, domain, target)
 }
 
@@ -100,9 +100,9 @@ func testLocalCNAMEResourceConfig(name string, domain string, target string) str
 // testCheckLocalCNAMEResourceExists checks that the CNAME record exists in Pi-hole
 func testCheckLocalCNAMEResourceExists(_ *testing.T, domain string, target string) resource.TestCheckFunc {
 	return func(*terraform.State) error {
-		client := testAccProvider.Meta().(*pihole.Client)
+		client := testAccProvider.Meta().(pihole.Client)
 
-		record, err := client.LocalCNAME.Get(context.Background(), domain)
+		record, err := client.LocalCNAME().Get(context.Background(), domain)
 		if err != nil {
 			return err
 		}
@@ -117,15 +117,15 @@ func testCheckLocalCNAMEResourceExists(_ *testing.T, domain string, target strin
 
 // testAccCheckCNAMERecordDestroy checks that all resources have been deleted
 func testAccCheckCNAMERecordDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*pihole.Client)
+	client := testAccProvider.Meta().(pihole.Client)
 
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "pihole_cname_record" {
 			continue
 		}
 
-		if _, err := client.LocalCNAME.Get(context.Background(), r.Primary.ID); err != nil {
-			if !errors.Is(err, pihole.ErrorLocalCNAMENotFound) {
+		if _, err := client.LocalCNAME().Get(context.Background(), r.Primary.ID); err != nil {
+			if !errors.Is(err, pihole.ErrCNAMENotFound) {
 				return err
 			}
 		}

--- a/internal/provider/resource_dns_record.go
+++ b/internal/provider/resource_dns_record.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	pihole "github.com/ryanwholey/go-pihole"
+	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
 )
 
 // resourceDNSRecord returns the local DNS Terraform resource management configuration
@@ -48,7 +48,7 @@ func resourceDNSRecordCreate(ctx context.Context, d *schema.ResourceData, meta i
 	domain := d.Get("domain").(string)
 	ip := d.Get("ip").(string)
 
-	_, err := client.LocalDNS.Create(ctx, domain, ip)
+	_, err := client.LocalDNS().Create(ctx, domain, ip)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -65,9 +65,9 @@ func resourceDNSRecordRead(ctx context.Context, d *schema.ResourceData, meta int
 		return diags
 	}
 
-	record, err := client.LocalDNS.Get(ctx, d.Id())
+	record, err := client.LocalDNS().Get(ctx, d.Id())
 	if err != nil {
-		if errors.Is(err, pihole.ErrorLocalDNSNotFound) {
+		if errors.Is(err, pihole.ErrDNSNotFound) {
 			d.SetId("")
 			return nil
 		}
@@ -93,7 +93,7 @@ func resourceDNSRecordDelete(ctx context.Context, d *schema.ResourceData, meta i
 		return diags
 	}
 
-	if err := client.LocalDNS.Delete(ctx, d.Id()); err != nil {
+	if err := client.LocalDNS().Delete(ctx, d.Id()); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_dns_record_test.go
+++ b/internal/provider/resource_dns_record_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	pihole "github.com/ryanwholey/go-pihole"
+	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
 )
 
 func TestAccLocalDNS(t *testing.T) {
@@ -42,15 +42,15 @@ func testLocalDNSResourceConfig(name string, domain string, ip string) string {
 		resource "pihole_dns_record" %q {
 			domain = %q
 			ip     = %q
-		}	
+		}
 	`, name, domain, ip)
 }
 
 func testCheckLocalDNSResourceExists(_ *testing.T, domain string, ip string) resource.TestCheckFunc {
 	return func(*terraform.State) error {
-		client := testAccProvider.Meta().(*pihole.Client)
+		client := testAccProvider.Meta().(pihole.Client)
 
-		record, err := client.LocalDNS.Get(context.Background(), domain)
+		record, err := client.LocalDNS().Get(context.Background(), domain)
 		if err != nil {
 			return err
 		}
@@ -64,15 +64,15 @@ func testCheckLocalDNSResourceExists(_ *testing.T, domain string, ip string) res
 }
 
 func testAccCheckLocalDNSDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*pihole.Client)
+	client := testAccProvider.Meta().(pihole.Client)
 
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "pihole_dns_record" {
 			continue
 		}
 
-		if _, err := client.LocalDNS.Get(context.Background(), r.Primary.ID); err != nil {
-			if !errors.Is(err, pihole.ErrorLocalDNSNotFound) {
+		if _, err := client.LocalDNS().Get(context.Background(), r.Primary.ID); err != nil {
+			if !errors.Is(err, pihole.ErrDNSNotFound) {
 				return err
 			}
 		}

--- a/internal/provider/validation.go
+++ b/internal/provider/validation.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"net"
 	"regexp"
 
@@ -27,7 +28,7 @@ func validateIPAddress() schema.SchemaValidateDiagFunc {
 	return validation.ToDiagFunc(func(v interface{}, k string) (warnings []string, errors []error) {
 		value := v.(string)
 		if ip := net.ParseIP(value); ip == nil {
-			errors = append(errors, validation.InvalidIPAddress(k, value).([]error)...)
+			errors = append(errors, fmt.Errorf("%q is not a valid IP address: %s", k, value))
 		}
 		return warnings, errors
 	})


### PR DESCRIPTION
## Summary
- Replace external `go-pihole` dependency with internal `internal/pihole` package
- Implement Pi-hole v6 API client with session-based authentication
- Full CRUD support for DNS A records and CNAME records
- Provider now uses interface-based design (`client.LocalDNS()` method access)

## Changes
- **New**: `internal/pihole/` - interfaces, types, and error definitions
- **New**: `internal/pihole/v6/` - v6 API implementation (client, dns, cname)
- **Modified**: Provider resources/data sources to use new internal client
- **Removed**: `github.com/ryanwholey/go-pihole` external dependency

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Acceptance tests pass against Pi-hole v6.3/v6.4 (`make testall`)
- [x] DNS A record create/update/delete verified
- [x] CNAME record create/update/delete verified