### PR TITLE
fix: add session logout to prevent session exhaustion

### DIFF
--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -13,6 +13,10 @@ type Client interface {
 
 	// SessionID returns the current session ID (for reuse across provider instances)
 	SessionID() string
+
+	// Logout terminates the current session with Pi-hole.
+	// This should be called when the provider is done to free up session slots.
+	Logout(ctx context.Context) error
 }
 
 // LocalDNSService manages local DNS A records (domain -> IP mappings)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
 	"github.com/poindexter12/terraform-provider-pihole/internal/version"
 )
 
@@ -52,18 +53,42 @@ func Provider() *schema.Provider {
 // configure configures a Pi-hole client to be used for terraform resource requests
 func configure(version string, provider *schema.Provider) func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	return func(ctx context.Context, d *schema.ResourceData) (client interface{}, diags diag.Diagnostics) {
-		client, err := Config{
+		// Check if a session ID was passed in externally (for testing or session reuse)
+		externalSessionID := os.Getenv("__PIHOLE_SESSION_ID")
+
+		piholeClient, err := Config{
 			Password:  d.Get("password").(string),
 			URL:       d.Get("url").(string),
 			UserAgent: provider.UserAgent("terraform-provider-pihole", version),
 			CAFile:    d.Get("ca_file").(string),
-			SessionID: os.Getenv("__PIHOLE_SESSION_ID"),
+			SessionID: externalSessionID,
 		}.Client(ctx)
 
 		if err != nil {
 			return nil, diag.FromErr(fmt.Errorf("failed to instantiate client: %w", err))
 		}
 
-		return client, diags
+		// Only register cleanup for sessions we created ourselves.
+		// Don't logout sessions passed in via __PIHOLE_SESSION_ID as those
+		// are managed externally (e.g., for testing or session pooling).
+		if externalSessionID == "" {
+			if stopCtx, ok := schema.StopContext(ctx); ok {
+				go cleanupOnStop(stopCtx, piholeClient)
+			}
+		}
+
+		return piholeClient, diags
 	}
+}
+
+// cleanupOnStop waits for the stop context to be cancelled
+// and then logs out the Pi-hole session to free up the session slot.
+func cleanupOnStop(stopCtx context.Context, client pihole.Client) {
+	<-stopCtx.Done()
+
+	// Use a fresh context for logout since stopCtx is cancelled
+	logoutCtx, cancel := context.WithTimeout(context.Background(), 5*1e9) // 5 seconds
+	defer cancel()
+
+	_ = client.Logout(logoutCtx) // Best effort - ignore errors
 }


### PR DESCRIPTION
## Summary
Prevents session exhaustion (429 errors) by properly logging out Pi-hole sessions when Terraform exits.

Fixes #10

## Changes
- Add `Logout()` method to `pihole.Client` interface
- Implement `Logout()` in v6 client (calls `DELETE /api/auth`)
- Register cleanup goroutine via `StopContext` in provider configure
- Skip logout for externally-managed sessions (`__PIHOLE_SESSION_ID`)

## Root Cause
Pi-hole has a default limit of 16 concurrent sessions. Previously, sessions were never closed, causing them to accumulate across Terraform runs until the limit was reached.

## Test plan
- [x] Unit tests pass
- [x] Acceptance tests pass against Pi-hole v6.3/v6.4
- [x] Verified logout API call works correctly