### PR TITLE
feat: add insecure_skip_verify option for TLS

### DIFF
--- a/internal/pihole/types.go
+++ b/internal/pihole/types.go
@@ -26,6 +26,11 @@ type Config struct {
 	// CAFile is an optional path to a CA certificate for TLS
 	CAFile string
 
+	// InsecureSkipVerify disables TLS certificate verification.
+	// WARNING: This is insecure and should only be used for testing
+	// or in environments where you trust the network.
+	InsecureSkipVerify bool
+
 	// SessionID can be provided to reuse an existing session
 	SessionID string
 }

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -21,16 +21,20 @@ type Config struct {
 	// Custom CA file
 	CAFile string
 
+	// InsecureSkipVerify disables TLS certificate verification
+	InsecureSkipVerify bool
+
 	// SessionID can be passed to reduce the number of requests against the /api/auth endpoint
 	SessionID string
 }
 
 func (c Config) Client(ctx context.Context) (pihole.Client, error) {
 	return v6.NewClient(ctx, pihole.Config{
-		BaseURL:   c.URL,
-		Password:  c.Password,
-		UserAgent: c.UserAgent,
-		CAFile:    c.CAFile,
-		SessionID: c.SessionID,
+		BaseURL:            c.URL,
+		Password:           c.Password,
+		UserAgent:          c.UserAgent,
+		CAFile:             c.CAFile,
+		InsecureSkipVerify: c.InsecureSkipVerify,
+		SessionID:          c.SessionID,
 	})
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,7 +30,13 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("PIHOLE_CA_FILE", nil),
-				Description: "CA file to connect to Pi-hole with TLS",
+				Description: "Path to a CA certificate file for TLS verification",
+			},
+			"insecure_skip_verify": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Skip TLS certificate verification. WARNING: This is insecure and should only be used for testing or in trusted networks with self-signed certificates.",
 			},
 		},
 
@@ -57,11 +63,12 @@ func configure(version string, provider *schema.Provider) func(ctx context.Conte
 		externalSessionID := os.Getenv("__PIHOLE_SESSION_ID")
 
 		piholeClient, err := Config{
-			Password:  d.Get("password").(string),
-			URL:       d.Get("url").(string),
-			UserAgent: provider.UserAgent("terraform-provider-pihole", version),
-			CAFile:    d.Get("ca_file").(string),
-			SessionID: externalSessionID,
+			Password:           d.Get("password").(string),
+			URL:                d.Get("url").(string),
+			UserAgent:          provider.UserAgent("terraform-provider-pihole", version),
+			CAFile:             d.Get("ca_file").(string),
+			InsecureSkipVerify: d.Get("insecure_skip_verify").(bool),
+			SessionID:          externalSessionID,
 		}.Client(ctx)
 
 		if err != nil {


### PR DESCRIPTION
## Summary
Add `insecure_skip_verify` provider option to skip TLS certificate verification for users with self-signed certificates.

Partially addresses #11

## Changes
- Add `insecure_skip_verify` boolean to provider schema (default: `false`)
- Add `InsecureSkipVerify` to `pihole.Config` struct
- Update v6 client TLS configuration to handle both `ca_file` and `insecure_skip_verify`

## Usage
```hcl
provider "pihole" {
  url                  = "https://pihole.local"
  password             = var.pihole_password
  insecure_skip_verify = true  # For self-signed certs
}
```

## ⚠️ Security Warning
This option disables certificate verification and should only be used:
- For testing/development environments
- On trusted internal networks with self-signed certificates
- When a CA file is not available

## Test plan
- [x] Unit tests pass
- [x] Acceptance tests pass against Pi-hole v6