### PR TITLE
feat: add force attribute to DNS and CNAME record resources

### DIFF
--- a/docs/resources/cname_record.md
+++ b/docs/resources/cname_record.md
@@ -27,6 +27,10 @@ resource "pihole_cname_record" "record" {
 - `domain` (String) Domain to create a CNAME record for
 - `target` (String) Value of the CNAME record where traffic will be directed to from the configured domain value
 
+### Optional
+
+- `force` (Boolean) Attempt to force record creation. Note: Pi-hole v6 API currently does not implement this for CNAME endpoints, but it is included for forward compatibility with future Pi-hole versions.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -27,6 +27,10 @@ resource "pihole_dns_record" "record" {
 - `domain` (String) DNS record domain
 - `ip` (String) IP address to route traffic to from the DNS record domain
 
+### Optional
+
+- `force` (Boolean) Attempt to force record creation. Note: Pi-hole v6 API currently does not implement this for DNS endpoints, but it is included for forward compatibility with future Pi-hole versions.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -19,9 +19,17 @@ type Client interface {
 	Logout(ctx context.Context) error
 }
 
+// CreateOptions contains optional parameters for record creation
+type CreateOptions struct {
+	// Force attempts to force record creation. Note: Pi-hole v6 API currently
+	// does not implement this for DNS/CNAME endpoints, but it's included for
+	// forward compatibility with future Pi-hole versions.
+	Force bool
+}
+
 // LocalDNSService manages local DNS A records (domain -> IP mappings)
 type LocalDNSService interface {
-	Create(ctx context.Context, domain, ip string) (*DNSRecord, error)
+	Create(ctx context.Context, domain, ip string, opts *CreateOptions) (*DNSRecord, error)
 	Get(ctx context.Context, domain string) (*DNSRecord, error)
 	List(ctx context.Context) ([]DNSRecord, error)
 	Delete(ctx context.Context, domain string) error
@@ -29,7 +37,7 @@ type LocalDNSService interface {
 
 // LocalCNAMEService manages CNAME records (domain -> target domain mappings)
 type LocalCNAMEService interface {
-	Create(ctx context.Context, domain, target string) (*CNAMERecord, error)
+	Create(ctx context.Context, domain, target string, opts *CreateOptions) (*CNAMERecord, error)
 	Get(ctx context.Context, domain string) (*CNAMERecord, error)
 	List(ctx context.Context) ([]CNAMERecord, error)
 	Delete(ctx context.Context, domain string) error

--- a/internal/pihole/v6/cname.go
+++ b/internal/pihole/v6/cname.go
@@ -63,8 +63,13 @@ func (s *cnameService) Get(ctx context.Context, domain string) (*pihole.CNAMERec
 }
 
 // Create adds a new CNAME record
-func (s *cnameService) Create(ctx context.Context, domain, target string) (*pihole.CNAMERecord, error) {
+func (s *cnameService) Create(ctx context.Context, domain, target string, opts *pihole.CreateOptions) (*pihole.CNAMERecord, error) {
 	path := fmt.Sprintf("%s/%s", cnamePath, url.PathEscape(domain+","+target))
+
+	// Append force parameter if requested
+	if opts != nil && opts.Force {
+		path += "?force=true"
+	}
 
 	resp, err := s.client.put(ctx, path, nil)
 	if err != nil {

--- a/internal/pihole/v6/dns.go
+++ b/internal/pihole/v6/dns.go
@@ -63,8 +63,13 @@ func (s *dnsService) Get(ctx context.Context, domain string) (*pihole.DNSRecord,
 }
 
 // Create adds a new DNS record
-func (s *dnsService) Create(ctx context.Context, domain, ip string) (*pihole.DNSRecord, error) {
+func (s *dnsService) Create(ctx context.Context, domain, ip string, opts *pihole.CreateOptions) (*pihole.DNSRecord, error) {
 	path := fmt.Sprintf("%s/%s", dnsHostsPath, url.PathEscape(ip+" "+domain))
+
+	// Append force parameter if requested
+	if opts != nil && opts.Force {
+		path += "?force=true"
+	}
 
 	resp, err := s.client.put(ctx, path, nil)
 	if err != nil {

--- a/internal/provider/resource_cname_record.go
+++ b/internal/provider/resource_cname_record.go
@@ -42,6 +42,13 @@ func resourceCNAMERecord() *schema.Resource {
 				ForceNew:         true,
 				ValidateDiagFunc: validateDomain(),
 			},
+			"force": {
+				Description: "Attempt to force record creation. Note: Pi-hole v6 API currently does not implement this for CNAME endpoints, but it is included for forward compatibility with future Pi-hole versions.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+			},
 		},
 	}
 }
@@ -55,11 +62,13 @@ func resourceCNAMERecordCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	domain := d.Get("domain").(string)
 	target := d.Get("target").(string)
+	force := d.Get("force").(bool)
 
 	cnameMutex.Lock()
 	defer cnameMutex.Unlock()
 
-	_, err := client.LocalCNAME().Create(ctx, domain, target)
+	opts := &pihole.CreateOptions{Force: force}
+	_, err := client.LocalCNAME().Create(ctx, domain, target, opts)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_dns_record.go
+++ b/internal/provider/resource_dns_record.go
@@ -42,6 +42,13 @@ func resourceDNSRecord() *schema.Resource {
 				ForceNew:         true,
 				ValidateDiagFunc: validateIPAddress(),
 			},
+			"force": {
+				Description: "Attempt to force record creation. Note: Pi-hole v6 API currently does not implement this for DNS endpoints, but it is included for forward compatibility with future Pi-hole versions.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+			},
 		},
 	}
 }
@@ -55,11 +62,13 @@ func resourceDNSRecordCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	domain := d.Get("domain").(string)
 	ip := d.Get("ip").(string)
+	force := d.Get("force").(bool)
 
 	dnsMutex.Lock()
 	defer dnsMutex.Unlock()
 
-	_, err := client.LocalDNS().Create(ctx, domain, ip)
+	opts := &pihole.CreateOptions{Force: force}
+	_, err := client.LocalDNS().Create(ctx, domain, ip, opts)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
## Summary

Add optional `force` boolean attribute to both `pihole_dns_record` and `pihole_cname_record` resources for forward compatibility with future Pi-hole versions.

Closes #17

## Usage

```hcl
resource "pihole_dns_record" "example" {
  domain = "example.local"
  ip     = "192.168.1.100"
  force  = true  # Optional, defaults to false
}

resource "pihole_cname_record" "example" {
  domain = "alias.local"
  target = "target.local"
  force  = true  # Optional, defaults to false
}
```

## Changes

- Add `CreateOptions` struct to pihole client interface with `Force` field
- Update `LocalDNSService.Create()` and `LocalCNAMEService.Create()` to accept options
- Add `force` schema attribute to both resources (optional, default false, ForceNew)
- Pass `?force=true` query parameter when force is enabled
- Regenerate documentation

## Current API Behavior

Testing shows Pi-hole v6 API currently **ignores** the `force` parameter for DNS/CNAME endpoints:
- DNS: Creates duplicate records regardless of force setting
- CNAME: Rejects duplicates at dnsmasq level regardless of force setting

This attribute is included for:
1. Forward compatibility with future Pi-hole versions
2. API consistency between provider and Pi-hole
3. User configuration clarity

## Test plan

- [x] `TestAccCNAMERecord` passes
- [x] `TestAccLocalDNS` passes
- [x] Documentation regenerated