### PR TITLE
fix: add LogoutAll to always call the logout endpoint on normal exit

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
 	"github.com/poindexter12/terraform-provider-pihole/internal/version"
 )
 
@@ -82,27 +80,23 @@ func configure(version string, provider *schema.Provider) func(ctx context.Conte
 		// Don't logout sessions passed in via __PIHOLE_SESSION_ID as those
 		// are managed externally (e.g., for testing or session pooling).
 		if externalSessionID == "" {
-			// StopContext is deprecated but still functional in SDK v2.
-			// The replacement (context-aware CRUD) doesn't provide stop signals.
+			// Registered sessions are logged out by LogoutAll, which main
+			// calls once plugin.Serve returns. That is the path taken on a
+			// normal Terraform run.
+			sessions.add(piholeClient)
+
+			// StopContext only fires when Terraform interrupts the provider,
+			// so it covers Ctrl-C and nothing else; the normal exit path is
+			// handled by main. It is deprecated but still functional in SDK
+			// v2, and the replacement (context-aware CRUD) provides no stop
+			// signal.
 			// TODO: Remove when migrating to terraform-plugin-framework.
 			if stopCtx, ok := schema.StopContext(ctx); ok { //nolint:staticcheck
-				go cleanupOnStop(stopCtx, piholeClient)
+				go cleanupOnStop(stopCtx)
 			}
 		}
 
 		// Return ProviderMeta which wraps the client and provides coordination
 		return &ProviderMeta{Client: piholeClient}, nil
 	}
-}
-
-// cleanupOnStop waits for the stop context to be cancelled
-// and then logs out the Pi-hole session to free up the session slot.
-func cleanupOnStop(stopCtx context.Context, client pihole.Client) {
-	<-stopCtx.Done()
-
-	// Use a fresh context for logout since stopCtx is cancelled
-	logoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	_ = client.Logout(logoutCtx) // Best effort - ignore errors
 }

--- a/internal/provider/session.go
+++ b/internal/provider/session.go
@@ -1,0 +1,104 @@
+package provider
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
+)
+
+// logoutTimeout bounds how long session cleanup may take during shutdown.
+//
+// When Terraform is done with a plugin it closes the connection and then waits
+// roughly two seconds for the process to exit before sending SIGKILL (see
+// Client.Kill in hashicorp/go-plugin). Cleanup has to fit inside that window,
+// so we deliberately leave a margin instead of claiming the whole budget.
+const logoutTimeout = 1500 * time.Millisecond
+
+// sessionRegistry tracks the Pi-hole clients whose sessions this process
+// opened and is therefore responsible for closing.
+//
+// Pi-hole allows a limited number of concurrent sessions
+// (webserver.api.max_sessions, 16 by default) and keeps them until
+// webserver.session.timeout elapses (30 minutes by default). A session left
+// behind by every plan and every apply eventually locks the user out of both
+// the API and the admin dashboard, so every session we open must be closed.
+//
+// A registry is needed rather than a single client because the provider is
+// configured once per provider instance: aliases and multiple provider blocks
+// each authenticate separately within a single run.
+type sessionRegistry struct {
+	mu      sync.Mutex
+	clients []pihole.Client
+}
+
+// sessions is the process-wide registry, drained on shutdown by LogoutAll.
+var sessions sessionRegistry
+
+// add records a client whose session should be terminated on shutdown.
+func (r *sessionRegistry) add(client pihole.Client) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.clients = append(r.clients, client)
+}
+
+// drain returns the registered clients and empties the registry. Shutdown can
+// be reached from more than one path, so draining is what makes logging out
+// idempotent: whichever path runs first takes the clients, the rest find none.
+func (r *sessionRegistry) drain() []pihole.Client {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	clients := r.clients
+	r.clients = nil
+
+	return clients
+}
+
+// logoutAll terminates every registered session concurrently and waits for the
+// results. Errors are ignored because cleanup is best effort: a failed logout
+// only leaves the session to expire on its own. Logout honours ctx, so a
+// deadline on ctx bounds the total time spent here no matter how many sessions
+// are registered.
+func (r *sessionRegistry) logoutAll(ctx context.Context) {
+	var wg sync.WaitGroup
+
+	for _, client := range r.drain() {
+		wg.Add(1)
+
+		go func(client pihole.Client) {
+			defer wg.Done()
+
+			_ = client.Logout(ctx)
+		}(client)
+	}
+
+	wg.Wait()
+}
+
+// LogoutAll terminates every Pi-hole session opened by this process.
+//
+// It is called from main once plugin.Serve returns, which is the only hook
+// that runs on a normal Terraform run: the SDK stop context backing
+// cleanupOnStop is cancelled only when Terraform interrupts the provider.
+// Calling it more than once is safe, and it does nothing when no sessions were
+// opened.
+func LogoutAll() {
+	ctx, cancel := context.WithTimeout(context.Background(), logoutTimeout)
+	defer cancel()
+
+	sessions.logoutAll(ctx)
+}
+
+// cleanupOnStop terminates registered sessions once Terraform signals a stop.
+// This covers interrupts (Ctrl-C), where Terraform may kill the process before
+// plugin.Serve returns and main gets a chance to clean up.
+func cleanupOnStop(stopCtx context.Context) {
+	<-stopCtx.Done()
+
+	// stopCtx is cancelled by the time we get here, so LogoutAll builds its
+	// own context rather than deriving from it.
+	LogoutAll()
+}

--- a/internal/provider/session_test.go
+++ b/internal/provider/session_test.go
@@ -1,0 +1,205 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/poindexter12/terraform-provider-pihole/internal/pihole"
+)
+
+// fakeClient is a pihole.Client that only implements what session cleanup
+// touches: it counts Logout calls and can block to exercise the deadline.
+type fakeClient struct {
+	logouts atomic.Int32
+
+	// block, when non-nil, holds Logout until it is closed or ctx expires.
+	block chan struct{}
+}
+
+func (f *fakeClient) LocalDNS() pihole.LocalDNSService                 { return nil }
+func (f *fakeClient) LocalCNAME() pihole.LocalCNAMEService             { return nil }
+func (f *fakeClient) ClientManagement() pihole.ClientManagementService { return nil }
+func (f *fakeClient) SessionID() string                                { return "fake-session" }
+
+func (f *fakeClient) Logout(ctx context.Context) error {
+	if f.block != nil {
+		select {
+		case <-f.block:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	f.logouts.Add(1)
+
+	return nil
+}
+
+// resetSessions isolates a test from sessions registered elsewhere in the
+// package, and leaves the registry empty for the tests that follow.
+func resetSessions(t *testing.T) {
+	t.Helper()
+
+	sessions.drain()
+	t.Cleanup(func() {
+		sessions.drain()
+	})
+}
+
+func TestSessionRegistryLogsOutEverySession(t *testing.T) {
+	resetSessions(t)
+
+	first, second := &fakeClient{}, &fakeClient{}
+	sessions.add(first)
+	sessions.add(second)
+
+	sessions.logoutAll(context.Background())
+
+	if got := first.logouts.Load(); got != 1 {
+		t.Errorf("first client logouts = %d, want 1", got)
+	}
+
+	if got := second.logouts.Load(); got != 1 {
+		t.Errorf("second client logouts = %d, want 1", got)
+	}
+}
+
+// Both the stop path and the normal exit path can run in the same process, so
+// a session must not be logged out twice.
+func TestSessionRegistryLogoutIsIdempotent(t *testing.T) {
+	resetSessions(t)
+
+	client := &fakeClient{}
+	sessions.add(client)
+
+	sessions.logoutAll(context.Background())
+	sessions.logoutAll(context.Background())
+
+	if got := client.logouts.Load(); got != 1 {
+		t.Errorf("logouts = %d, want 1", got)
+	}
+}
+
+// Cleanup runs inside go-plugin's shutdown grace period, so an unreachable
+// Pi-hole must not keep the process alive past the context deadline.
+func TestSessionRegistryLogoutRespectsDeadline(t *testing.T) {
+	resetSessions(t)
+
+	blocked := &fakeClient{block: make(chan struct{})}
+	defer close(blocked.block)
+
+	sessions.add(blocked)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		sessions.logoutAll(ctx)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("logoutAll did not return after its context expired")
+	}
+}
+
+// authServer stands in for Pi-hole's /api/auth endpoint and reports whether a
+// session was ever deleted.
+func authServer(t *testing.T) (*httptest.Server, func() bool) {
+	t.Helper()
+
+	var mu sync.Mutex
+	deleted := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/auth" {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		switch r.Method {
+		case http.MethodPost:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"session":{"sid":"test-session"}}`))
+		case http.MethodDelete:
+			mu.Lock()
+			deleted = true
+			mu.Unlock()
+
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		}
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return deleted
+	}
+}
+
+func configureProvider(t *testing.T, url string) {
+	t.Helper()
+
+	provider := Provider()
+	data := schema.TestResourceDataRaw(t, provider.Schema, map[string]interface{}{
+		"url":      url,
+		"password": "test",
+	})
+
+	if _, diags := configure("test", provider)(context.Background(), data); diags.HasError() {
+		t.Fatalf("configure returned diagnostics: %v", diags)
+	}
+}
+
+func TestConfigureSessionIsLoggedOutOnShutdown(t *testing.T) {
+	resetSessions(t)
+	t.Setenv("__PIHOLE_SESSION_ID", "")
+
+	server, wasDeleted := authServer(t)
+
+	configureProvider(t, server.URL)
+
+	if wasDeleted() {
+		t.Fatal("session was deleted before shutdown")
+	}
+
+	LogoutAll()
+
+	if !wasDeleted() {
+		t.Error("session was not deleted on shutdown")
+	}
+}
+
+// Sessions supplied through __PIHOLE_SESSION_ID belong to whoever created
+// them, so shutdown must leave them alone.
+func TestConfigureExternalSessionIsNotLoggedOut(t *testing.T) {
+	resetSessions(t)
+	t.Setenv("__PIHOLE_SESSION_ID", "externally-managed")
+
+	server, wasDeleted := authServer(t)
+
+	configureProvider(t, server.URL)
+
+	LogoutAll()
+
+	if wasDeleted() {
+		t.Error("externally managed session was deleted on shutdown")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -9,4 +9,11 @@ func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: provider.Provider,
 	})
+
+	// plugin.Serve returns once Terraform closes the plugin connection, which
+	// makes this the only cleanup hook that runs on a successful Terraform
+	// run: the SDK stop context is cancelled on interrupt only. Terraform
+	// allows roughly two seconds before SIGKILL, and LogoutAll stays inside
+	// that window.
+	provider.LogoutAll()
 }


### PR DESCRIPTION
Fix the issue https://github.com/poindexter12/terraform-provider-pihole/issues/27 and also add test for this case. It was also tested on a real pihole instance