### PR TITLE
chore: resolve Scorecard findings — pin all actions, restrict release permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,20 +32,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         if: matrix.language == 'go'
         with:
           go-version-file: go.mod
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,13 @@ on:
       - 'v*'
 
 permissions:
-  contents: write # Needed by goreleaser to create the GitHub release.
+  contents: read
 
 jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
+    permissions:
+      contents: write # Needed by goreleaser to create the GitHub release.
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@5f388ae147bcc1e1c34822571b2f2de40694c5d6 # v5
     secrets:
       gpg-private-key: '${{ secrets.GPG_PRIVATE_KEY }}'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -32,6 +32,6 @@ jobs:
           publish_results: true
 
       - name: Upload results to code scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif

--- a/.github/workflows/test-scheduled.yml
+++ b/.github/workflows/test-scheduled.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
Addresses the actionable code-scanning alerts from the OpenSSF Scorecard scans introduced in #31.

## Fixed here (14 alerts)
- **PinnedDependenciesID (13)** — the hardening PR SHA-pinned third-party actions; this pins the remaining first-party ones (`actions/checkout`, `actions/setup-go`, `github/codeql-action`) to full commit SHAs with version comments. Bumped to current majors while at it (checkout v7.0.1, setup-go v7.0.0, codeql-action v4.37.6), which also clears the Node 20 runner deprecation warnings.
- **TokenPermissionsID (1)** — `release.yml` now defaults to `contents: read` at workflow level, granting `contents: write` only to the release job that goreleaser needs it for.

## Expected to self-resolve on the next weekly Scorecard scan (scanned before/during #31 landing)
- `SASTID` — CodeQL now runs on every PR
- `VulnerabilitiesID` — all reachable vulns fixed (#31, #33); govulncheck reports clean
- `CITestsID` — acceptance-test workflows re-enabled and running on PRs

## Deliberately not addressed (repo-policy decisions, not code)
- `BranchProtectionID` / `CodeReviewID` — would require mandatory PRs + reviews on `main`; current ruleset intentionally preserves direct pushes (blocks only force-push/deletion)
- `FuzzingID` / `CIIBestPracticesID` — aspirational (OSS-Fuzz enrollment, OpenSSF badge program); can be pursued separately if desired

Scorecard runs on push to `main` + weekly cron, so alert closure lands after merge.