### PR TITLE
chore: test against current Pi-hole release alongside the v6 baseline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,9 @@ jobs:
       fail-fast: false
 
       matrix:
-        tag: 
-          - "2025.03.0" # Recent FTL v6
+        tag:
+          - "2025.03.0" # Oldest supported FTL v6 baseline
+          - "2026.07.2" # Current release — bump when new Pi-hole versions ship
 
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         tag:
           - "2025.03.0" # Oldest supported FTL v6 baseline
-          - "2026.07.2" # Current release — bump when new Pi-hole versions ship
+          - "latest" # Current stable release, tracks new Pi-hole versions automatically
 
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
The `Test selected versions` matrix pinned a single Pi-hole image, `2025.03.0` (March 2025) — ~18 months behind the current `2026.07.2`. This keeps `2025.03.0` as the oldest-supported FTL v6 baseline and adds `2026.07.2`, so every PR runs the acceptance suite against both ends of the supported range (`fail-fast: false` already isolates failures per version; the weekly scheduled workflow continues to cover `nightly`).