### PR TITLE
test: add Go native fuzz tests for parsers and validators

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,40 @@
+name: Fuzz
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "examples/**"
+      - "templates/**"
+  schedule:
+    - cron: "0 12 * * 1" # 12:00 every Monday.
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Fuzz each target
+        shell: bash
+        run: |
+          set -euo pipefail
+          for pkg in ./internal/pihole/v6 ./internal/provider; do
+            for target in $(go test "$pkg" -list '^Fuzz' | grep '^Fuzz'); do
+              echo "::group::${pkg} ${target}"
+              go test "$pkg" -run '^$' -fuzz "^${target}\$" -fuzztime=60s
+              echo "::endgroup::"
+            done
+          done

--- a/internal/pihole/v6/fuzz_test.go
+++ b/internal/pihole/v6/fuzz_test.go
@@ -1,0 +1,71 @@
+package v6
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzParseDNSHosts exercises the "IP domain" parser that consumes strings
+// from Pi-hole API responses. Invariants: never panics, never returns more
+// records than inputs, and every record round-trips to an entry that was in
+// the input.
+func FuzzParseDNSHosts(f *testing.F) {
+	f.Add("192.168.1.1 example.lan")
+	f.Add("::1 v6.example.lan")
+	f.Add("no-space-entry")
+	f.Add("")
+	f.Add("1.2.3.4 host with extra spaces")
+
+	f.Fuzz(func(t *testing.T, entry string) {
+		records := parseDNSHosts([]string{entry})
+
+		if len(records) > 1 {
+			t.Fatalf("one input produced %d records", len(records))
+		}
+
+		for _, r := range records {
+			if r.IP+" "+r.Domain != entry {
+				t.Fatalf("record %+v does not round-trip to input %q", r, entry)
+			}
+			if strings.Contains(r.IP, " ") {
+				t.Fatalf("IP %q contains a space", r.IP)
+			}
+		}
+
+		// Entries without a separator must be dropped, not mangled
+		if !strings.Contains(entry, " ") && len(records) != 0 {
+			t.Fatalf("entry %q without separator produced a record", entry)
+		}
+	})
+}
+
+// FuzzParseCNAMEs exercises the "domain,target" parser with the same
+// invariants as FuzzParseDNSHosts.
+func FuzzParseCNAMEs(f *testing.F) {
+	f.Add("alias.lan,target.lan")
+	f.Add("no-comma-entry")
+	f.Add("")
+	f.Add("a,b,c")
+	f.Add(",")
+
+	f.Fuzz(func(t *testing.T, entry string) {
+		records := parseCNAMEs([]string{entry})
+
+		if len(records) > 1 {
+			t.Fatalf("one input produced %d records", len(records))
+		}
+
+		for _, r := range records {
+			if r.Domain+","+r.Target != entry {
+				t.Fatalf("record %+v does not round-trip to input %q", r, entry)
+			}
+			if strings.Contains(r.Domain, ",") {
+				t.Fatalf("domain %q contains a comma", r.Domain)
+			}
+		}
+
+		if !strings.Contains(entry, ",") && len(records) != 0 {
+			t.Fatalf("entry %q without separator produced a record", entry)
+		}
+	})
+}

--- a/internal/provider/validation_fuzz_test.go
+++ b/internal/provider/validation_fuzz_test.go
@@ -1,0 +1,55 @@
+package provider
+
+import (
+	"net"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+)
+
+// FuzzValidateDomain exercises the domain validator with arbitrary input.
+// Invariants: never panics, and anything it accepts satisfies the documented
+// length bounds.
+func FuzzValidateDomain(f *testing.F) {
+	f.Add("example.lan")
+	f.Add("")
+	f.Add("-leading.dash")
+	f.Add("a.very.deeply.nested.sub.domain.example.com")
+	f.Add("under_score.lan")
+	f.Add("💥.emoji")
+
+	validate := validateDomain()
+
+	f.Fuzz(func(t *testing.T, domain string) {
+		diags := validate(domain, cty.Path{})
+
+		if !diags.HasError() {
+			if len(domain) == 0 || len(domain) > 253 {
+				t.Fatalf("validator accepted %q with invalid length %d", domain, len(domain))
+			}
+		}
+	})
+}
+
+// FuzzValidateIPAddress checks the IP validator never panics and always
+// agrees with net.ParseIP.
+func FuzzValidateIPAddress(f *testing.F) {
+	f.Add("192.168.1.1")
+	f.Add("::1")
+	f.Add("999.999.999.999")
+	f.Add("")
+	f.Add("1.2.3.4.5")
+
+	validate := validateIPAddress()
+
+	f.Fuzz(func(t *testing.T, ip string) {
+		diags := validate(ip, cty.Path{})
+
+		parseable := net.ParseIP(ip) != nil
+		accepted := !diags.HasError()
+
+		if parseable != accepted {
+			t.Fatalf("validator (%v) disagrees with net.ParseIP (%v) for %q", accepted, parseable, ip)
+		}
+	})
+}


### PR DESCRIPTION
Addresses the Scorecard `FuzzingID` alert with genuinely useful coverage rather than enrollment ceremony — Scorecard's Fuzzing check recognizes Go native fuzzing.

## Targets
- `FuzzParseDNSHosts` / `FuzzParseCNAMEs` — the parsers that consume Pi-hole API response strings. Invariants: no panics, one record max per entry, exact round-trip to the input, separator-less entries dropped.
- `FuzzValidateDomain` — accepted values must satisfy the documented length bounds; no regex panics.
- `FuzzValidateIPAddress` — must agree exactly with `net.ParseIP`.

## CI
New `fuzz.yml` workflow (SHA-pinned actions, `contents: read`): discovers all `Fuzz*` targets and runs each for 60s on PRs and weekly. All four targets passed 15s local bursts with zero findings.