### PR TITLE
chore: osv-scanner exception for unfixable advisory + always-run required checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,17 +3,10 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'examples/**'
-      - 'templates/**'
+  # No paths-ignore: lint is a required status check on main, so it must
+  # report on every PR — path-filtered workflows never run on docs-only PRs,
+  # which would leave the required check pending forever.
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'examples/**'
-      - 'templates/**'
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,17 +5,10 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "examples/**"
-      - "templates/**"
+  # No paths-ignore: these jobs are required status checks on main, so they
+  # must report on every PR — path-filtered workflows never run on docs-only
+  # PRs, which would leave required checks pending forever.
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "examples/**"
-      - "templates/**"
   schedule:
     - cron: "0 12 * * 1" # 12:00 every Monday.
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,15 @@
+# Configuration for osv-scanner (also consumed by the OpenSSF Scorecard
+# Vulnerabilities check). Each ignore documents a finding that cannot be
+# fixed by a dependency update; remove entries as soon as a fix exists.
+
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = """
+golang.org/x/crypto/openpgp is deprecated by design and the advisory has no
+fixed version at any x/crypto release. The package is never imported by this
+module (`go mod why golang.org/x/crypto/openpgp` reports it is not needed;
+govulncheck confirms no reachable call path) — the x/crypto module enters the
+graph transitively via the HashiCorp terraform-plugin-sdk chain and cannot be
+removed. Re-evaluate if the advisory gains a fixed version or the SDK drops
+the dependency.
+"""


### PR DESCRIPTION
Second part of the Scorecard remediation (with #36).

## osv-scanner.toml
`GO-2026-5932` (`x/crypto/openpgp` — deprecated by design, **no fixed version exists at any x/crypto release**) cannot be fixed by bumping: the module enters the graph transitively via the terraform-plugin-sdk chain, and `go mod why` + govulncheck confirm the package is never imported nor reachable. This checks in a documented, code-reviewed exception instead of a UI dismissal. **Verification pending**: after merge, the next Scorecard run on main will show whether its embedded osv-scanner honors the config — if it doesn't, the alert stays open with this file as the documented rationale.

## paths-ignore removal (lint.yml, test.yml)
Prep for making `lint` and both `test (…)` jobs required status checks on `main`: a path-filtered workflow never runs on a docs-only PR, so its required check would stay pending forever and block the merge. Cost: docs-only PRs now run ~2–3 min of CI. The fuzz/scheduled workflows keep their filters (not required checks).