### PR TITLE
fix: transparently re-authenticate when the Pi-hole session is invalidated

### DIFF
--- a/internal/pihole/v6/client.go
+++ b/internal/pihole/v6/client.go
@@ -187,8 +187,31 @@ func (c *Client) SessionPassword() string {
 	return c.password
 }
 
-// request performs an authenticated HTTP request
+// request performs an authenticated HTTP request. If the session has been
+// invalidated (Pi-hole purges all sessions on any password change — on some
+// FTL versions in a delayed second pass — and expires idle sessions after
+// webserver.session.timeout), it re-authenticates once with the stored
+// credential and retries the request.
 func (c *Client) request(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
+	resp, err := c.doRequest(ctx, method, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+	resp.Body.Close()
+
+	if err := c.authenticate(ctx); err != nil {
+		return nil, fmt.Errorf("session expired and re-authentication failed: %w", err)
+	}
+
+	return c.doRequest(ctx, method, path, body)
+}
+
+// doRequest performs a single authenticated HTTP request without retry
+func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
 	var bodyReader io.Reader
 	if body != nil {
 		jsonBody, err := json.Marshal(body)

--- a/internal/pihole/v6/password_test.go
+++ b/internal/pihole/v6/password_test.go
@@ -34,6 +34,11 @@ type mockPihole struct {
 	// password to reject before accepting it.
 	propagationDelay     int
 	propagationRemaining int
+
+	// delayedPurges simulates older FTL versions that purge sessions again
+	// asynchronously after a password change: each pending purge kills all
+	// sessions right before the next authenticated request is validated.
+	delayedPurges int
 }
 
 func newMockPihole(adminPassword string) *mockPihole {
@@ -147,6 +152,12 @@ func (m *mockPihole) handler() http.Handler {
 func (m *mockPihole) validSession(r *http.Request) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if m.delayedPurges > 0 {
+		m.delayedPurges--
+		m.sessions = map[string]bool{}
+	}
+
 	return m.sessions[r.Header.Get(sessionHeader)]
 }
 
@@ -264,6 +275,67 @@ func TestPasswordUpdatePreservesAppPasswordAuth(t *testing.T) {
 
 	if _, err := client.Password().GetHash(context.Background()); err != nil {
 		t.Fatalf("GetHash with app password session: %v", err)
+	}
+}
+
+// TestSessionReauthOnExpiry verifies the client transparently recovers when
+// its session is invalidated between requests (idle timeout, or another
+// actor changing the password).
+func TestSessionReauthOnExpiry(t *testing.T) {
+	mock := newMockPihole("initial")
+	client, _ := newTestClient(t, mock, "initial")
+
+	mock.delayedPurges = 1 // next request finds its session dead
+
+	hash, err := client.Password().GetHash(context.Background())
+	if err != nil {
+		t.Fatalf("expected transparent re-authentication, got: %v", err)
+	}
+	if hash != "$MOCK-HASH$v=1" {
+		t.Fatalf("unexpected hash: %q", hash)
+	}
+}
+
+// TestPasswordUpdateSurvivesDelayedPurge simulates older FTL versions where a
+// password change is followed by a second asynchronous session purge: the
+// session obtained by Update's re-authentication dies before the next call.
+func TestPasswordUpdateSurvivesDelayedPurge(t *testing.T) {
+	mock := newMockPihole("initial")
+	client, _ := newTestClient(t, mock, "initial")
+
+	if err := client.Password().Update(context.Background(), "rotated"); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	mock.delayedPurges = 1 // the async purge lands now
+
+	hash, err := client.Password().GetHash(context.Background())
+	if err != nil {
+		t.Fatalf("expected recovery from delayed purge, got: %v", err)
+	}
+	if hash != "$MOCK-HASH$v=2" {
+		t.Fatalf("unexpected hash: %q", hash)
+	}
+}
+
+// TestSessionReauthFailurePropagates verifies a clear error when the session
+// is dead and the stored credential no longer authenticates.
+func TestSessionReauthFailurePropagates(t *testing.T) {
+	mock := newMockPihole("initial")
+	client, _ := newTestClient(t, mock, "initial")
+
+	// Password changed out-of-band: stored credential is now wrong
+	mock.mu.Lock()
+	mock.adminPassword = "changed-elsewhere"
+	mock.sessions = map[string]bool{}
+	mock.mu.Unlock()
+
+	_, err := client.Password().GetHash(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "re-authentication failed") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/provider/resource_password_test.go
+++ b/internal/provider/resource_password_test.go
@@ -70,6 +70,14 @@ func TestAccPasswordRotation(t *testing.T) {
 
 	ctx := context.Background()
 
+	// Every password set in this test kills all sessions, including the
+	// shared __PIHOLE_SESSION_ID the rest of the suite reuses. Refresh it
+	// unconditionally when the test ends — t.Cleanup runs after the deferred
+	// password restore below, so it always sees the restored password. If
+	// this ran only on the success path, a failure here would cascade 401s
+	// into every subsequent test.
+	t.Cleanup(func() { refreshSharedSession(t) })
+
 	client, err := Config{URL: url, Password: original}.Client(ctx)
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
@@ -126,10 +134,6 @@ func TestAccPasswordRotation(t *testing.T) {
 	if err := client.Logout(ctx); err != nil {
 		t.Logf("logout failed: %v", err)
 	}
-
-	// This test rotated the password twice, killing all sessions each time,
-	// including the shared __PIHOLE_SESSION_ID used by the rest of the suite.
-	refreshSharedSession(t)
 }
 
 // testPasswordResourceConfig returns HCL to configure the password resource


### PR DESCRIPTION
Root-causes the 401 cascade seen on PR #39's `test (2025.03.0)` run (attempt 1) — this was **not** the #38 already-present flake.

## What happened
`TestAccPasswordRotation` authenticated a fresh client, read the hash successfully, then got 401 on its PATCH ~1s later. On older FTL (2025.03.0), a password change is followed by a **delayed second session purge** that outlives the provider's immediate poll-verified re-authentication. On current FTL the purge is atomic, which is why this never reproduced on `latest` or locally. The test then compounded it: its shared-session refresh was the last line of the function, so the failure left `__PIHOLE_SESSION_ID` dead and every subsequent test 401'd.

## Fix
- **Client**: any request answered with 401 re-authenticates once using the stored credential and retries. This heals the delayed purge, real-world mid-apply session expiry (Pi-hole's 30-min idle timeout on long applies), and stale externally supplied session IDs. Auth/logout paths bypass the retry (no recursion).
- **Test**: the rotation test's shared-session refresh moved to `t.Cleanup`, which runs after the deferred password restore — failures no longer cascade.

## Testing
- New unit tests on the mock (which now simulates delayed purges): transparent recovery mid-sequence, recovery after `Update` when the async purge lands, and a clear error when the stored credential itself no longer works.
- Full local acceptance suite green; lint clean.

This matters for real users of `pihole_password` on older FTL — without it, a plan that changes the password and then touches DNS records can fail mid-apply. Worth landing before v1.2.0 (#39).