### PR TITLE
fix: converge on 'already present' when creating DNS/CNAME records

### DIFF
--- a/internal/pihole/v6/cname.go
+++ b/internal/pihole/v6/cname.go
@@ -101,11 +101,24 @@ func (s *cnameService) Create(ctx context.Context, domain, target string, opts *
 
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-
-		// Check if this is a retryable error (duplicate/conflict during ForceNew)
 		bodyStr := string(body)
-		if resp.StatusCode == http.StatusBadRequest && (strings.Contains(bodyStr, "duplicate CNAME") || strings.Contains(bodyStr, "already present")) {
-			lastErr = fmt.Errorf("item already present (attempt %d/%d): %s", attempt+1, maxRetries, bodyStr)
+
+		// Pi-hole enforces uniqueness on the full "domain,target" item, so
+		// "already present" can only mean the exact record we want already
+		// exists — the desired state is reached (see issue #38). "duplicate
+		// CNAME" is different: dnsmasq rejects a second CNAME for the same
+		// domain with another target, which can resolve once a pending delete
+		// completes, so it stays retryable.
+		if resp.StatusCode == http.StatusBadRequest && strings.Contains(bodyStr, "already present") {
+			tflog.Warn(ctx, "CNAME record already exists with the desired value, adopting it", map[string]interface{}{
+				"domain": domain,
+				"target": target,
+			})
+			return &pihole.CNAMERecord{Domain: domain, Target: target}, nil
+		}
+
+		if resp.StatusCode == http.StatusBadRequest && strings.Contains(bodyStr, "duplicate CNAME") {
+			lastErr = fmt.Errorf("conflicting CNAME for domain exists (attempt %d/%d): %s", attempt+1, maxRetries, bodyStr)
 			continue
 		}
 

--- a/internal/pihole/v6/dns.go
+++ b/internal/pihole/v6/dns.go
@@ -67,8 +67,9 @@ func (s *dnsService) Get(ctx context.Context, domain string) (*pihole.DNSRecord,
 
 // Create adds a new DNS record.
 // If opts.Force is true and the record already exists, it will be deleted first.
-// Includes retry logic for transient errors that can occur during
-// ForceNew operations when Pi-hole hasn't fully processed a prior delete.
+// An "already present" response is treated as success since Pi-hole enforces
+// uniqueness on the full "IP domain" item — the existing record is exactly
+// the desired one.
 func (s *dnsService) Create(ctx context.Context, domain, ip string, opts *pihole.CreateOptions) (*pihole.DNSRecord, error) {
 	// If force is requested and record exists, delete it first
 	if opts != nil && opts.Force {
@@ -86,44 +87,34 @@ func (s *dnsService) Create(ctx context.Context, domain, ip string, opts *pihole
 
 	path := fmt.Sprintf("%s/%s", dnsHostsPath, url.PathEscape(ip+" "+domain))
 
-	const maxRetries = 5
-	var lastErr error
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		if attempt > 0 {
-			// Exponential backoff: 200ms, 400ms, 800ms, 1600ms
-			delay := time.Duration(200<<uint(attempt-1)) * time.Millisecond
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(delay):
-			}
-		}
-
-		resp, err := s.client.put(ctx, path, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		if resp.StatusCode == http.StatusCreated {
-			resp.Body.Close()
-			return &pihole.DNSRecord{Domain: domain, IP: ip}, nil
-		}
-
-		body, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-
-		// Check if this is a retryable error (duplicate/conflict during ForceNew)
-		bodyStr := string(body)
-		if resp.StatusCode == http.StatusBadRequest && strings.Contains(bodyStr, "already present") {
-			lastErr = fmt.Errorf("item already present (attempt %d/%d): %s", attempt+1, maxRetries, bodyStr)
-			continue
-		}
-
-		// Non-retryable error
-		return nil, fmt.Errorf("unexpected status code: %d (expected 201): %s", resp.StatusCode, bodyStr)
+	resp, err := s.client.put(ctx, path, nil)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, lastErr
+	if resp.StatusCode == http.StatusCreated {
+		resp.Body.Close()
+		return &pihole.DNSRecord{Domain: domain, IP: ip}, nil
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// Pi-hole enforces uniqueness on the full "IP domain" item, so "already
+	// present" can only mean the exact record we want already exists — the
+	// desired state is reached. Treating it as success makes creates converge
+	// instead of flaking when FTL's config write-back resurrects a deleted
+	// record (its dnsmasq-test child processes race under rapid mutations,
+	// losing committed deletes; see issue #38).
+	if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "already present") {
+		tflog.Warn(ctx, "DNS record already exists with the desired value, adopting it", map[string]interface{}{
+			"domain": domain,
+			"ip":     ip,
+		})
+		return &pihole.DNSRecord{Domain: domain, IP: ip}, nil
+	}
+
+	return nil, fmt.Errorf("unexpected status code: %d (expected 201): %s", resp.StatusCode, string(body))
 }
 
 // Delete removes a DNS record.


### PR DESCRIPTION
Fixes #38.

## Root cause (confirmed empirically)
- **Resurrection proven**: after a failed stress loop, a single record (`10.0.0.3 stress-dns-3.local`) remained in Pi-hole even though `Delete()`'s 10-attempt verification and `CheckDestroy` had both confirmed it gone — the delete un-happened afterwards.
- **Mechanism**: with `debug.config` enabled, FTL logs an endless `Waiting for dnsmasq test returned: No child process` loop under rapid mutations — its per-commit `dnsmasq --test` child processes race on reaping (ECHILD), and a commit whose validation is lost gets dropped or overwritten by a concurrent writer's stale snapshot. Deletes silently revert.
- **Amplifier**: a create failing with `already present` never enters Terraform state, so no destroy ever owns the zombie — it poisons every subsequent run (locally reproduced: 9/10 stress-suite loops failing, durations growing as retries piled up).

## Fix
Pi-hole enforces uniqueness on the **full item string** (verified: `1.2.3.4 uniq.local` and `5.6.7.8 uniq.local` both create fine), so `already present` can only mean the exact desired record already exists. Create now adopts it (logged at WARN) instead of retrying five times and failing — desired-state convergence, same philosophy as the 401 re-auth fix in #40. The DNS create retry loop collapses to a single attempt; CNAME keeps its retry solely for `duplicate CNAME` (same domain, *different* target — a genuine conflict that can clear when a pending delete completes).

## Verification
- 10× `TestAccStress` loop against a clean instance: **9/10 failing before → 10/10 passing after**
- Full `make testall` green; lint clean
- Worth reporting upstream to pi-hole/FTL (ECHILD race in config commit path) — happy to file that separately

Side finding from the investigation, for the record: Pi-hole restores API sessions from disk across restarts (`webserver.session.restore`), so a wedged/full-seats instance needs `docker compose down && up`, not `docker restart`.